### PR TITLE
[codex] Use trusted local copy for GPT panelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ attributed to the panelist that raised it, so you can see how the answer was ass
   session model — on another model the slug is nominal, not literal).
 - For `opus4.8-gpt5.5`: the [`codex` CLI](https://github.com/openai/codex) installed and logged in to an
   account with GPT-5.5 access. The runner uses `codex exec` (tested against `codex-cli` 0.139).
+  It runs against a throwaway copy of the current repo/workdir with trusted local access so tools such as
+  `gh`, local test runners, Docker, and SDK-managed toolchains behave like they do in your terminal without
+  writing back to the live checkout.
 - For the 3-model panel: a `gemini` CLI installed and authenticated. Adjust the invocation in
   `skills/fusion/scripts/run_gemini.sh` to match your CLI's flags.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ attributed to the panelist that raised it, so you can see how the answer was ass
   It runs against a throwaway copy of the current repo/workdir with trusted local access so tools such as
   `gh`, local test runners, Docker, and SDK-managed toolchains behave like they do in your terminal without
   writing back to the live checkout.
+  Each Fusion invocation uses its own temporary prompt/output directory, so concurrent runs in different
+  Claude Code sessions do not read each other's GPT panelist artifacts.
 - For the 3-model panel: a `gemini` CLI installed and authenticated. Adjust the invocation in
   `skills/fusion/scripts/run_gemini.sh` to match your CLI's flags.
 

--- a/skills/fusion/SKILL.md
+++ b/skills/fusion/SKILL.md
@@ -60,13 +60,18 @@ Launch **all panelists in a single turn** so they run concurrently:
   Spawn them in the same message so they run at once; each returned answer is one panel response.
 - **GPT-5.5 panelist** → write its prompt to a temp file and run in the background:
   ```bash
-  bash <skill_dir>/scripts/run_codex.sh /tmp/fusion_codex_prompt.txt /tmp/fusion_codex_out.md xhigh
+  fusion_run_dir="$(mktemp -d "${TMPDIR:-/tmp}/fusion-panel.XXXXXX")"
+  bash <skill_dir>/scripts/run_codex.sh "$fusion_run_dir/codex_prompt.md" "$fusion_run_dir/codex_out.md" xhigh
   ```
+  Allocate one unique `fusion_run_dir` per Fusion invocation and put every prompt/output file for that
+  invocation under it. Never use fixed paths like `/tmp/fusion_codex_prompt.txt` or
+  `/tmp/fusion_codex_out.md`; multiple Claude Code sessions can run Fusion concurrently, and fixed names
+  let one run read another run's prompt or answer.
   The runner copies the current repo/workdir to a throwaway directory, then launches `codex exec` with
   full local access against that copy. This preserves the live checkout while letting the GPT-5.5 panelist
   use the same local tools and keychain-backed credentials as a trusted terminal Codex run. `-o` makes
   codex write only its final answer to the out file; read it once it finishes.
-- **Gemini panelist** → `bash <skill_dir>/scripts/run_gemini.sh /tmp/fusion_gemini_prompt.txt /tmp/fusion_gemini_out.md`.
+- **Gemini panelist** → `bash <skill_dir>/scripts/run_gemini.sh "$fusion_run_dir/gemini_prompt.md" "$fusion_run_dir/gemini_out.md"`.
   Exit 127 means the CLI isn't installed — drop Gemini and note the panel downgraded.
 
 Keep panelists isolated: never paste one panelist's output into another's prompt. The orchestrator (you)

--- a/skills/fusion/SKILL.md
+++ b/skills/fusion/SKILL.md
@@ -60,9 +60,12 @@ Launch **all panelists in a single turn** so they run concurrently:
   Spawn them in the same message so they run at once; each returned answer is one panel response.
 - **GPT-5.5 panelist** → write its prompt to a temp file and run in the background:
   ```bash
-  bash <skill_dir>/scripts/run_codex.sh /tmp/fusion_codex_prompt.txt /tmp/fusion_codex_out.md medium
+  bash <skill_dir>/scripts/run_codex.sh /tmp/fusion_codex_prompt.txt /tmp/fusion_codex_out.md xhigh
   ```
-  `-o` makes codex write only its final answer to the out file; read it once it finishes.
+  The runner copies the current repo/workdir to a throwaway directory, then launches `codex exec` with
+  full local access against that copy. This preserves the live checkout while letting the GPT-5.5 panelist
+  use the same local tools and keychain-backed credentials as a trusted terminal Codex run. `-o` makes
+  codex write only its final answer to the out file; read it once it finishes.
 - **Gemini panelist** → `bash <skill_dir>/scripts/run_gemini.sh /tmp/fusion_gemini_prompt.txt /tmp/fusion_gemini_out.md`.
   Exit 127 means the CLI isn't installed — drop Gemini and note the panel downgraded.
 

--- a/skills/fusion/scripts/run_codex.sh
+++ b/skills/fusion/scripts/run_codex.sh
@@ -6,27 +6,77 @@
 #
 # - <prompt_file>   : path to a file containing the FULL panelist prompt (verbatim user task + brief instruction)
 # - <output_file>   : where the panelist's final answer is written (clean, just the answer)
-# - reasoning_effort: low | medium | high   (default: medium)
+# - reasoning_effort: low | medium | high | xhigh   (default: xhigh)
 #
 # Notes:
 # - `-o/--output-last-message` writes ONLY the agent's final message — no streaming noise to parse.
-# - `-s workspace-write` lets the panelist run shell commands in an isolated scratch dir (the "bash tool").
+# - The panelist runs against a temporary copy of the current repo/workdir, so its file writes do not
+#   touch your live checkout.
+# - `--dangerously-bypass-approvals-and-sandbox` intentionally gives the panelist the same local tool
+#   access as a normal trusted Codex CLI run. This is needed for macOS keychain-backed tools like `gh`.
 # - `-c tools.web_search=true` enables the web search tool.
-# - We run in a throwaway scratch dir so a panelist's file writes never touch your repo.
+# - The throwaway copy is deleted when the panelist exits.
 
 set -uo pipefail
 
 prompt_file="${1:?usage: run_codex.sh <prompt_file> <output_file> [reasoning_effort]}"
 output_file="${2:?usage: run_codex.sh <prompt_file> <output_file> [reasoning_effort]}"
-effort="${3:-medium}"
+effort="${3:-xhigh}"
+
+case "$prompt_file" in
+  /*) ;;
+  *) prompt_file="$(pwd -P)/$prompt_file" ;;
+esac
+case "$output_file" in
+  /*) ;;
+  *) output_file="$(pwd -P)/$output_file" ;;
+esac
 
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/fusion-codex.XXXXXX")"
 trap 'rm -rf "$scratch"' EXIT
+workdir="$scratch/workdir"
+
+source_root="$(pwd -P)"
+source_subdir=""
+if git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  source_root="$(cd "$git_root" && pwd -P)"
+  current_dir="$(pwd -P)"
+  case "$current_dir" in
+    "$source_root") source_subdir="" ;;
+    "$source_root"/*) source_subdir="${current_dir#"$source_root"/}" ;;
+    *) source_subdir="" ;;
+  esac
+fi
+
+mkdir -p "$workdir"
+if command -v rsync >/dev/null 2>&1; then
+  rsync -a \
+    --exclude '.git/index.lock' \
+    --exclude '.git/shallow.lock' \
+    --exclude '.git/worktrees/*/index.lock' \
+    "$source_root"/ "$workdir"/
+else
+  cp -R "$source_root"/. "$workdir"/
+fi
+
+panel_cwd="$workdir"
+if [ -n "$source_subdir" ]; then
+  panel_cwd="$workdir/$source_subdir"
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  if gh auth status --active --hostname github.com >/dev/null 2>&1; then
+    echo "[run_codex.sh] gh auth ok in parent environment" >&2
+  else
+    echo "[run_codex.sh] warning: gh auth is not usable in parent environment" >&2
+  fi
+fi
 
 codex exec \
   --skip-git-repo-check \
-  --cd "$scratch" \
-  -s workspace-write \
+  --ephemeral \
+  --cd "$panel_cwd" \
+  --dangerously-bypass-approvals-and-sandbox \
   -c tools.web_search=true \
   -c "model_reasoning_effort=$effort" \
   -o "$output_file" \

--- a/skills/fusion/scripts/run_codex.sh
+++ b/skills/fusion/scripts/run_codex.sh
@@ -32,6 +32,13 @@ case "$output_file" in
   *) output_file="$(pwd -P)/$output_file" ;;
 esac
 
+if [ ! -s "$prompt_file" ]; then
+  echo "[run_codex.sh] prompt file is missing or empty: $prompt_file" >&2
+  exit 2
+fi
+mkdir -p "$(dirname "$output_file")"
+rm -f "$output_file"
+
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/fusion-codex.XXXXXX")"
 trap 'rm -rf "$scratch"' EXIT
 workdir="$scratch/workdir"


### PR DESCRIPTION
## Summary

This changes the GPT-5.5 Fusion panelist runner so `codex exec` runs against a temporary copy of the current repo/workdir with trusted local access, instead of running inside an empty sandboxed scratch directory.

The runner still keeps the live checkout isolated: it copies the current git root/workdir to `/tmp/fusion-codex.../workdir`, runs the GPT panelist there, and deletes the copy on exit.

This also makes Fusion panel artifacts parallel-safe. Each Fusion invocation now allocates a unique temporary prompt/output directory instead of using fixed `/tmp/fusion_codex_*.md` paths.

## Why

The previous runner launched GPT-5.5 with:

```bash
codex exec --cd "$scratch" -s workspace-write ...
```

That caused three practical problems:

- the GPT panelist did not naturally see the repo/test suite because it started in an empty scratch directory
- macOS keychain-backed tools such as `gh` could fail inside the Codex workspace sandbox, making a valid GitHub auth token appear invalid
- concurrent Fusion runs in different Claude Code sessions could race on the same fixed `/tmp/fusion_codex_prompt.txt` and `/tmp/fusion_codex_out.md` files, letting one run read another run prompt or answer

This meant Opus could access GitHub/test context while GPT-5.5 sometimes had to rely only on local prompt context and docs, or could return an answer from a different concurrent Fusion run.

## Changes

- Copy the current git root/workdir into a throwaway directory before launching GPT-5.5.
- Preserve the caller subdirectory when the runner is invoked from inside a repo subdir.
- Launch `codex exec` with `--dangerously-bypass-approvals-and-sandbox` against the throwaway copy so local tools behave like they do in a trusted terminal Codex run.
- Keep GPT-5.5 reasoning default at `xhigh`.
- Require one unique `fusion_run_dir` per Fusion invocation for panel prompt/output files.
- Add runner guards for missing/empty prompt files and stale output files.
- Document the new runner behavior in the skill and README.

## Validation

- Ran `bash -n skills/fusion/scripts/run_codex.sh`.
- Ran a real low-reasoning runner smoke test that asked GPT-5.5 to execute `gh auth status --active --hostname github.com` without printing tokens.
- Verified the GPT panelist saw GitHub auth successfully and reported that it was running inside a copied `fusion-codex` workdir.
- Verified a missing prompt file exits with code 2 and leaves no stale output.
- Reinstalled the skill with `./install.sh`.