### PR TITLE
feat: add opus4.8-gemini3.1pro panel and fix Windows agy execution

### DIFF
--- a/commands/fusion-gemini.md
+++ b/commands/fusion-gemini.md
@@ -1,0 +1,21 @@
+---
+description: Fusion panel of Opus 4.8 + Gemini 3.1 Pro in parallel, judged by Opus 4.8 (opus4.8-gemini3.1pro)
+argument-hint: <your question>
+---
+Invoke the **fusion** skill on the task below, forcing the `opus4.8-gemini3.1pro` panel:
+Opus 4.8 (Agent subagent) and Gemini 3.1 Pro (via `agy`, pseudo-TTY) answer the SAME prompt IN PARALLEL,
+each independently with web + bash and neither seeing the other's work → Opus 4.8 judges both answers → Opus
+writes the final answer grounded in the analysis.
+
+Follow the skill's SKILL.md exactly (preflight → fan out in parallel → judge picking the track that fits the
+task → grounded final deliverable → save provenance → present). For a research/analysis task present the
+standard sections (Consensus / Contradictions / Partial coverage / Unique insights / Blind spots / Final
+answer); for a code/artifact task run both candidates and merge them into one working result with a merge
+rationale. Use exactly one Opus 4.8 panelist and one Gemini 3.1 Pro panelist — do NOT add a GPT-5.5 panelist
+or a second Opus run. Pass the task verbatim to both; no "lenses".
+
+If the `agy` CLI is missing or the Gemini panelist fails/times out, drop it, record a one-line degradation
+note, and fall back to `opus4.8-4.8` (spawn a second independent Opus panelist) so the judge still sees two
+blind answers — never abort because one CLI failed.
+
+Task: $ARGUMENTS

--- a/skills/fusion/SKILL.md
+++ b/skills/fusion/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   independently with web search and bash, none seeing the others' work — then having Opus 4.8 judge every
   response into a structured analysis (consensus, contradictions, partial coverage, unique insights, blind
   spots) and write a final answer grounded in it. The panel is two independent Opus 4.8 runs (slug
-  opus4.8-4.8), Opus 4.8 + GPT-5.5 via codex (opus4.8-gpt5.5), or those plus Gemini 3.1 Pro via agy
-  (opus4.8-gpt5.5-gemini3.1pro). Opus always judges and writes the final answer — the pipeline can't be
+  opus4.8-4.8), Opus 4.8 + GPT-5.5 via codex (opus4.8-gpt5.5), Opus 4.8 + Gemini 3.1 Pro via agy
+  (opus4.8-gemini3.1pro), or all three (opus4.8-gpt5.5-gemini3.1pro). Opus always judges and writes the final answer — the pipeline can't be
   reversed. Runs on local CLI subscriptions (no metered API), saves a timestamped provenance .md per run,
   and answers in French by default. Use this whenever the user asks to "run it through Fusion", says
   /fusion, wants a multi-model / panel / ensemble answer, wants a question cross-checked across models, or
@@ -48,6 +48,7 @@ It prints a `SLUG=` line recommending the richest panel possible on this machine
 | --- | --- | --- |
 | `opus4.8-4.8` | the same prompt run twice as 2 independent Opus 4.8 panelists | nothing — always available |
 | `opus4.8-gpt5.5` | Opus 4.8 + GPT-5.5 in parallel | `codex` CLI |
+| `opus4.8-gemini3.1pro` | Opus 4.8 + Gemini 3.1 Pro in parallel | `agy` CLI |
 | `opus4.8-gpt5.5-gemini3.1pro` | Opus 4.8 + GPT-5.5 + Gemini 3.1 Pro in parallel | `codex` + `agy` CLIs |
 
 If the user named a slug (or used a pinned `/fusion-*` command), honor it — but if a required CLI is
@@ -75,6 +76,8 @@ Launch **all panelists in a single turn** so they run concurrently:
 
 - **Opus 4.8 panelist(s)** → the `Agent` tool, `subagent_type: general-purpose` (web + bash built in).
   For `opus4.8-4.8`, spawn **two** independent Opus subagents with the *same* prompt — two cold runs.
+  For every other slug (`opus4.8-gpt5.5`, `opus4.8-gemini3.1pro`, `opus4.8-gpt5.5-gemini3.1pro`) spawn
+  **exactly one** Opus panelist alongside the external panelist(s).
   Spawn them in the same message so they run at once. When each returns, write its answer to a temp file
   for provenance: `/tmp/fusion_opusA.md` (and `/tmp/fusion_opusB.md` for the second Opus run).
 - **GPT-5.5 panelist** (if slug includes it) → write its prompt to a temp file, then run:
@@ -107,7 +110,9 @@ subagents, not you, so your synthesis reads all answers fresh.
 **Graceful degradation.** If an external panelist exits non-zero, remove it, record a one-line degradation
 note (e.g. `gemini dropped: agy empty -> opus4.8-gpt5.5`), and continue with what's left. Order of fallback:
 `opus4.8-gpt5.5-gemini3.1pro` → `opus4.8-gpt5.5` → ultimate `opus4.8-4.8` (two independent Opus runs, zero
-external CLI). A degraded run still completes; never abort because one CLI failed.
+external CLI). For `opus4.8-gemini3.1pro`, dropping Gemini falls back to `opus4.8-4.8` (spawn a second
+independent Opus panelist) so the judge still sees two blind answers. A degraded run still completes; never
+abort because one CLI failed.
 
 ## Step 3 — Judge (pick the track that fits the task)
 

--- a/skills/fusion/references/panel.md
+++ b/skills/fusion/references/panel.md
@@ -27,6 +27,7 @@ answers meet. Cross-pollination before the judge defeats the entire mechanism.
 - `opus4.8-4.8` — the **same prompt run twice** as two independent Opus 4.8 panelists (Agent subagents),
   then judged. Same model, two cold runs.
 - `opus4.8-gpt5.5` — Opus 4.8 and GPT-5.5 (codex) answer **in parallel**, then judged.
+- `opus4.8-gemini3.1pro` — Opus 4.8 and Gemini 3.1 Pro (agy) answer **in parallel**, then judged.
 - `opus4.8-gpt5.5-gemini3.1pro` — Opus 4.8, GPT-5.5, and Gemini 3.1 Pro answer in parallel, then judged.
 
 In every case Opus 4.8 is also the judge/synthesizer, and the judge is kept separate from the panelists

--- a/skills/fusion/scripts/agy_capture.py
+++ b/skills/fusion/scripts/agy_capture.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Windows-native capture for the Antigravity Gemini CLI (`agy`).
+
+`agy -p` renders its answer to the Windows console (ConPTY), so piped stdout is
+empty and there is no PTY/jq path on this box. But agy writes every turn to a
+per-conversation transcript on disk. This helper runs a single prompt in an
+isolated workspace directory (so the conversation is fresh and unambiguous),
+waits for the model's response to land in that transcript, prints it to stdout,
+and cleans up the lingering agy process.
+
+Usage:
+    agy_capture.py "<prompt>"            # prompt as arg
+    echo "<prompt>" | agy_capture.py -   # prompt on stdin
+
+Exit codes: 0 = response captured (printed to stdout); non-zero = failure.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HOME = Path(os.path.expanduser("~"))
+CLI = HOME / ".gemini" / "antigravity-cli"
+LCJ = CLI / "cache" / "last_conversations.json"
+BRAIN = CLI / "brain"
+AGY = HOME / "AppData" / "Local" / "agy" / "bin" / "agy.exe"
+
+# A MODEL turn carrying the final text answer.
+MODEL_TYPES = {"PLANNER_RESPONSE", "ASSISTANT_RESPONSE", "MODEL_RESPONSE", "RESPONSE"}
+
+POLL_SECONDS = float(os.environ.get("AGY_POLL_SECONDS", "300"))
+QUIET_SECONDS = float(os.environ.get("AGY_QUIET_SECONDS", "8"))  # stop once transcript stops growing
+
+
+def transcript_for(conv_id: str) -> Path:
+    return BRAIN / conv_id / ".system_generated" / "logs" / "transcript.jsonl"
+
+
+def conv_id_for(ws: str):
+    try:
+        m = json.loads(LCJ.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    # keys are stored with Windows backslashes
+    for k, v in m.items():
+        if os.path.normcase(os.path.normpath(k)) == os.path.normcase(os.path.normpath(ws)):
+            return v
+    return None
+
+
+def model_text(tpath: Path) -> str:
+    if not tpath.exists():
+        return ""
+    out = []
+    for ln in tpath.read_text(encoding="utf-8", errors="replace").splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            o = json.loads(ln)
+        except Exception:
+            continue
+        if o.get("source") == "MODEL" and (o.get("type") in MODEL_TYPES):
+            c = o.get("content")
+            if c:
+                out.append(c)
+    return "\n".join(out).strip()
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        sys.stderr.write("usage: agy_capture.py '<prompt>' | echo p | agy_capture.py -\n")
+        return 2
+    prompt = sys.stdin.read() if sys.argv[1] == "-" else sys.argv[1]
+    prompt = prompt.strip()
+    if not prompt:
+        sys.stderr.write("empty prompt\n")
+        return 2
+
+    ws = tempfile.mkdtemp(prefix="fusion_agy_")
+    cmd = [str(AGY), "-p", prompt,
+           "--dangerously-skip-permissions",
+           "--print-timeout", f"{int(POLL_SECONDS)}s"]
+    model = os.environ.get("AGY_MODEL", "").strip()
+    if model:
+        cmd += ["--model", model]
+    proc = subprocess.Popen(
+        cmd,
+        cwd=ws,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+    )
+
+    deadline = time.time() + POLL_SECONDS
+    conv_id = None
+    last_text = ""
+    last_change = None
+    while time.time() < deadline:
+        if conv_id is None:
+            conv_id = conv_id_for(ws)
+        if conv_id:
+            txt = model_text(transcript_for(conv_id))
+            if txt and txt != last_text:
+                last_text = txt
+                last_change = time.time()
+            # response present and transcript quiet for QUIET_SECONDS => done
+            if last_text and last_change and (time.time() - last_change) > QUIET_SECONDS:
+                break
+        if proc.poll() is not None and last_text:
+            break
+        time.sleep(1)
+
+    # tear down the lingering agy language server
+    try:
+        proc.terminate()
+    except Exception:
+        pass
+    try:
+        subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        pass
+
+    if not last_text:
+        sys.stderr.write(f"agy_capture: no MODEL response captured (ws={ws}, conv={conv_id})\n")
+        return 1
+    sys.stdout.write(last_text + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/fusion/scripts/agy_capture.py
+++ b/skills/fusion/scripts/agy_capture.py
@@ -22,6 +22,15 @@ import tempfile
 import time
 from pathlib import Path
 
+# agy answers routinely contain non-Latin-1 glyphs (≤, ≥, –, ✓, math symbols). On Windows,
+# Python defaults stdout to cp1252 when redirected to a pipe/file, which raises
+# UnicodeEncodeError mid-write and leaves the output empty. Force UTF-8.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
 HOME = Path(os.path.expanduser("~"))
 CLI = HOME / ".gemini" / "antigravity-cli"
 LCJ = CLI / "cache" / "last_conversations.json"

--- a/skills/fusion/scripts/detect_panel.sh
+++ b/skills/fusion/scripts/detect_panel.sh
@@ -21,6 +21,7 @@ printf "  gemini3.1pro : %s (agy CLI)\n"    "$([ "$agy_ok"   = true ] && echo ye
 echo
 
 if   $codex_ok && $agy_ok; then slug="opus4.8-gpt5.5-gemini3.1pro"
+elif $agy_ok;              then slug="opus4.8-gemini3.1pro"
 elif $codex_ok;            then slug="opus4.8-gpt5.5"
 else                            slug="opus4.8-4.8"
 fi

--- a/skills/fusion/scripts/preflight.sh
+++ b/skills/fusion/scripts/preflight.sh
@@ -14,7 +14,7 @@ prompt_file="${2:?usage: preflight.sh <slug> <prompt_file>}"
 
 case "$slug" in
   opus4.8-gpt5.5-gemini3.1pro) n=3 ;;
-  opus4.8-gpt5.5|opus4.8-4.8)  n=2 ;;
+  opus4.8-gpt5.5|opus4.8-gemini3.1pro|opus4.8-4.8)  n=2 ;;
   *)                           n=2 ;;
 esac
 

--- a/skills/fusion/scripts/run_gemini.sh
+++ b/skills/fusion/scripts/run_gemini.sh
@@ -52,6 +52,31 @@ if [ -z "${FUSION_AGY_NO_MODEL:-}" ] && [ -n "$AGY_MODEL" ]; then
   agy_args+=( --model "$AGY_MODEL" )
 fi
 
+# --- Voie W: Windows transcript capture (no PTY on this platform) ----------------------
+# On Windows (MSYS/Git-Bash) there is no usable PTY: python lacks the `pty`/`termios`
+# modules and `script` is absent, so voie A always yields empty stdout. agy DOES contact
+# Gemini and writes the answer to its per-conversation transcript on disk. agy_capture.py
+# runs the prompt in an isolated workspace dir and reads the MODEL response straight back
+# out of that transcript. Use it directly here and skip voie A/B.
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*)
+    cap_py="$SCRIPT_DIR/agy_capture.py"
+    if have python && [ -f "$cap_py" ]; then
+      # No --model: agy's configured default is already Gemini 3.1 Pro (High), and passing
+      # --model in print mode can hang (see bug notes). Opt in via FUSION_AGY_FORCE_MODEL.
+      AGY_MODEL="${FUSION_AGY_FORCE_MODEL:-}" \
+      AGY_POLL_SECONDS="$FUSION_TIMEOUT" \
+        python "$cap_py" "$(cat "$prompt_file")" > "$output_file" 2> "$scratch/stderr.log"
+      if [ -s "$output_file" ]; then
+        echo "[run_gemini.sh] ok (voie W: Windows transcript capture) -> $output_file"
+        exit 0
+      fi
+      echo "[run_gemini.sh] voie W empty — falling through to voie A/B." >&2
+      [ -s "$scratch/stderr.log" ] && tail -5 "$scratch/stderr.log" >&2
+    fi
+    ;;
+esac
+
 # --- Voie A: pseudo-TTY (survives socket stdio in cmux / headless) ---------------------
 # agy bug #76 needs a real TTY on stdout. `script -q /dev/null` calls tcgetattr() on fd 0 and
 # ABORTS when the orchestrator runs in a socket (cmux/headless: "tcgetattr/ioctl: Operation not

--- a/skills/fusion/scripts/run_gemini.sh
+++ b/skills/fusion/scripts/run_gemini.sh
@@ -60,12 +60,18 @@ fi
 # fd 0 termios; fall back to `script` only if python3 is missing (plain TTY contexts).
 # sed strips ANSI (ESC[...m) and the literal "^D" caret-notation; tr removes residual control
 # bytes (CR, etc.) while keeping tab + newline.
-if have python3; then
+if have python3 && python3 -c 'import pty' 2>/dev/null; then
   pty_runner=( python3 "$SCRIPT_DIR/_pty_run.py" )
-else
+elif have script; then
   pty_runner=( script -q /dev/null )
+else
+  pty_runner=()
 fi
-_run_with_timeout "$EXT_TIMEOUT" "${pty_runner[@]}" agy "${agy_args[@]}" \
+orig_id="${ANTIGRAVITY_CONVERSATION_ID:-}"
+unset ANTIGRAVITY_CONVERSATION_ID
+export ANTIGRAVITY_AGENT=0
+
+_run_with_timeout "$EXT_TIMEOUT" "${pty_runner[@]}" agy "${agy_args[@]}" < /dev/null \
   2> "$scratch/stderr.log" \
   | sed -e 's/\x1b\[[0-9;]*m//g' -e 's/\^D//g' \
   | LC_ALL=C tr -d '\000-\010\013-\037\177' > "$output_file"
@@ -74,10 +80,26 @@ _run_with_timeout "$EXT_TIMEOUT" "${pty_runner[@]}" agy "${agy_args[@]}" \
 if [ ! -s "$output_file" ]; then
   echo "[run_gemini.sh] voie A vide (bug #76 probable) — fallback transcript JSONL." >&2
   tr="$(find "$BRAIN_DIR" -name transcript.jsonl -newer "$ts_marker" -print0 2>/dev/null \
-        | xargs -0 ls -t 2>/dev/null | head -1)"
+        | xargs -0 ls -t 2>/dev/null | awk -v oid="$orig_id" 'oid == "" || index($0, oid) == 0 {print; exit}')"
   if [ -n "$tr" ] && [ -s "$tr" ]; then
-    jq -rs 'map(select(.source=="MODEL" and .status=="DONE" and .type=="PLANNER_RESPONSE"))
-            | (last // {}) | .content // empty' "$tr" > "$output_file" 2>/dev/null
+    if have jq; then
+      jq -rs 'map(select(.source=="MODEL" and .status=="DONE" and .type=="PLANNER_RESPONSE"))
+              | (last // {}) | .content // empty' "$tr" > "$output_file" 2>/dev/null
+    elif have python3; then
+      python3 -c '
+import sys, json
+ans = ""
+for line in sys.stdin:
+    try:
+        d = json.loads(line)
+        if d.get("source") == "MODEL" and d.get("status") == "DONE" and d.get("type") == "PLANNER_RESPONSE":
+            if "content" in d and d["content"]:
+                ans = d["content"]
+    except: pass
+if ans:
+    print(ans, end="")
+' < "$tr" > "$output_file" 2>/dev/null
+    fi
   fi
 fi
 


### PR DESCRIPTION
This PR adds the `opus4.8-gemini3.1pro` panel slug and fixes several Windows/MSYS execution bugs in `run_gemini.sh`:

1.  **Removed Unix PTY assumptions (`script` / `pty.fork`)**: Dropped the pseudo-TTY requirement natively when running on Windows since those modules aren't available. Instead, it gracefully allows `agy` to run directly and natively handles the resulting empty-stdout bug.
2.  **Added a `jq`-free JSONL parser**: MSYS on Windows doesn't ship with `jq` by default, which broke the transcript parsing fallback ("Voie B"). Added a lightweight Python one-liner using the Windows Store Python that accomplishes the exact same extraction.
3.  **Prevented Transcript Collisions**: Updated the script to unset `ANTIGRAVITY_CONVERSATION_ID` and explicitly filter out the orchestrator's transcript to guarantee it always pulls the correct isolated transcript generated by the `agy -p` child process.

These changes have been tested locally and successfully allow the Gemini panel to execute and return results on Windows.
